### PR TITLE
Refactor setup-gradle tasks

### DIFF
--- a/.github/workflows/http4k.yml
+++ b/.github/workflows/http4k.yml
@@ -33,7 +33,5 @@ jobs:
         cache: gradle
 
     - name: Build
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: build
+      run: ./gradlew build
         build-root-directory: http4k-app

--- a/.github/workflows/http4k.yml
+++ b/.github/workflows/http4k.yml
@@ -22,16 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up Java
-      uses: actions/setup-java@v4
-      with:
-        java-version: 21
-        distribution: temurin
-        cache: gradle
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: gradle
 
-    - name: Build
-      run: ./gradlew build
-        build-root-directory: http4k-app
+      - name: Build
+        working-directory: http4k-app
+        run: ./gradlew build

--- a/.github/workflows/ktor.yml
+++ b/.github/workflows/ktor.yml
@@ -22,16 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up Java
-      uses: actions/setup-java@v4
-      with:
-        java-version: 21
-        distribution: temurin
-        cache: gradle
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: gradle
 
-    - name: Build
-      run: ./gradlew build
-        build-root-directory: ktor-app
+      - name: Build
+        working-directory: ktor-app
+        run: ./gradlew build

--- a/.github/workflows/ktor.yml
+++ b/.github/workflows/ktor.yml
@@ -33,7 +33,5 @@ jobs:
         cache: gradle
 
     - name: Build
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: build
+      run: ./gradlew build
         build-root-directory: ktor-app

--- a/.github/workflows/micronaut.yml
+++ b/.github/workflows/micronaut.yml
@@ -33,7 +33,5 @@ jobs:
         cache: gradle
 
     - name: Build
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: build
+      run: ./gradlew build
         build-root-directory: micronaut-app

--- a/.github/workflows/micronaut.yml
+++ b/.github/workflows/micronaut.yml
@@ -22,16 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up Java
-      uses: actions/setup-java@v4
-      with:
-        java-version: 17
-        distribution: temurin
-        cache: gradle
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
 
-    - name: Build
-      run: ./gradlew build
-        build-root-directory: micronaut-app
+      - name: Build
+        working-directory: micronaut-app
+        run: ./gradlew build

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -22,16 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up Java
-      uses: actions/setup-java@v4
-      with:
-        java-version: 21
-        distribution: temurin
-        cache: gradle
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: gradle
 
-    - name: Build
-      run: ./gradlew build
-        build-root-directory: quarkus-app
+      - name: Build
+        working-directory: quarkus-app
+        run: ./gradlew build

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -33,7 +33,5 @@ jobs:
         cache: gradle
 
     - name: Build
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: build
+      run: ./gradlew build
         build-root-directory: quarkus-app

--- a/.github/workflows/springboot.yml
+++ b/.github/workflows/springboot.yml
@@ -33,7 +33,5 @@ jobs:
         cache: gradle
 
     - name: Build
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: build
+      run: ./gradlew build
         build-root-directory: springboot-app

--- a/.github/workflows/springboot.yml
+++ b/.github/workflows/springboot.yml
@@ -22,16 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up Java
-      uses: actions/setup-java@v4
-      with:
-        java-version: 21
-        distribution: temurin
-        cache: gradle
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: gradle
 
-    - name: Build
-      run: ./gradlew build
-        build-root-directory: springboot-app
+      - name: Build
+        working-directory: springboot-app
+        run: ./gradlew build


### PR DESCRIPTION

This job uses deprecated functionality from the gradle/actions/setup-gradle action. Follow the links for upgrade details.
[Using the action to execute Gradle via the `arguments` parameter is deprecated](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated)