### PR TITLE
Fix http4k-app Gradle build for Gradle 9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![SpringBoot](https://github.com/rogervinas/top-5-server-side-kotlin-frameworks-2022/actions/workflows/springboot.yml/badge.svg)](https://github.com/rogervinas/top-5-server-side-kotlin-frameworks-2022/actions/workflows/springboot.yml)
 ![Java](https://img.shields.io/badge/Java-21-blue?labelColor=black)
 ![Kotlin](https://img.shields.io/badge/Kotlin-2.x-blue?labelColor=black)
-![SpringBoot](https://img.shields.io/badge/SpringBoot-4.x-blue?labelColor=black)
+![SpringBoot](https://img.shields.io/badge/SpringBoot-4.0.6-blue?labelColor=black)
 
 [![Quarkus](https://github.com/rogervinas/top-5-server-side-kotlin-frameworks-2022/actions/workflows/quarkus.yml/badge.svg)](https://github.com/rogervinas/top-5-server-side-kotlin-frameworks-2022/actions/workflows/quarkus.yml)
 ![Java](https://img.shields.io/badge/Java-17-blue?labelColor=black)
@@ -16,7 +16,7 @@
 [![Ktor](https://github.com/rogervinas/top-5-server-side-kotlin-frameworks-2022/actions/workflows/ktor.yml/badge.svg)](https://github.com/rogervinas/top-5-server-side-kotlin-frameworks-2022/actions/workflows/ktor.yml)
 ![Java](https://img.shields.io/badge/Java-21-blue?labelColor=black)
 ![Kotlin](https://img.shields.io/badge/Kotlin-2.x-blue?labelColor=black)
-![Ktor](https://img.shields.io/badge/Ktor-3.x-blue?labelColor=black)
+![Ktor](https://img.shields.io/badge/Ktor-3.4.1-blue?labelColor=black)
 
 [![Http4k](https://github.com/rogervinas/top-5-server-side-kotlin-frameworks-2022/actions/workflows/http4k.yml/badge.svg)](https://github.com/rogervinas/top-5-server-side-kotlin-frameworks-2022/actions/workflows/http4k.yml)
 ![Java](https://img.shields.io/badge/Java-21-blue?labelColor=black)

--- a/http4k-app/build.gradle.kts
+++ b/http4k-app/build.gradle.kts
@@ -5,7 +5,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
 plugins {
   kotlin("jvm") version "2.3.10"
   application
-  id("com.github.johnrengelman.shadow") version "8.1.1"
+  id("com.gradleup.shadow") version "9.0.0-beta12"
   id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
 }
 
@@ -45,8 +45,10 @@ dependencies {
 
   testImplementation("org.http4k:http4k-testing-approval:$http4kVersion")
   testImplementation("org.http4k:http4k-testing-hamkrest:$http4kVersion")
-  testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-  testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+
+  testImplementation(platform("org.junit:junit-bom:$junitVersion"))
+  testImplementation("org.junit.jupiter:junit-jupiter")
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
   testImplementation("io.mockk:mockk:1.14.9")
   testImplementation("org.testcontainers:junit-jupiter:1.21.4")

--- a/http4k-app/src/main/kotlin/org/rogervinas/GreetingRepository.kt
+++ b/http4k-app/src/main/kotlin/org/rogervinas/GreetingRepository.kt
@@ -6,7 +6,9 @@ interface GreetingRepository {
   fun getGreeting(): String
 }
 
-class GreetingJdbcRepository(private val connection: Connection) : GreetingRepository {
+class GreetingJdbcRepository(
+  private val connection: Connection,
+) : GreetingRepository {
   init {
     createGreetingsTable()
   }


### PR DESCRIPTION
## Summary
- Upgrade Shadow plugin to com.gradleup.shadow 9.0.0-beta12 (fixes `fileMode` incompatibility with Gradle 9.x)
- Use junit-bom for version alignment and add missing junit-platform-launcher dependency

## Checklist
- Verify the build compiles without errors
- Verify tests still run correctly