### PR TITLE
Add docker-compose to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,10 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"      
+  - package-ecosystem: docker-compose
+    directory: /
+    schedule:
+      interval: weekly
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Summary
- Add `docker-compose` package ecosystem to Dependabot so images in `docker-compose.yaml` (e.g. postgres, vault) get update PRs

## Checklist
- Verify Dependabot picks up the docker-compose.yaml and proposes image updates