### PR TITLE
Fix Testcontainers PostgreSQL wait strategy

### DIFF
--- a/http4k-app/README.md
+++ b/http4k-app/README.md
@@ -233,7 +233,7 @@ class GreetingApplicationTest {
     private val container = DockerComposeContainer(File("../docker-compose.yaml"))
       .withServices("db", "vault", "vault-cli")
       .withLocalCompose(true)
-      .waitingFor("db", forLogMessage(".*database system is ready to accept connections.*", 1))
+      .waitingFor("db", forLogMessage(".*listening on IPv4 address \"0.0.0.0\", port 5432.*", 1))
       .waitingFor("vault", forLogMessage(".*Development mode.*", 1))
       .waitingFor("vault-cli", forLogMessage(".*created_time.*", 1))
   }

--- a/http4k-app/src/test/kotlin/org/rogervinas/GreetingApplicationTest.kt
+++ b/http4k-app/src/test/kotlin/org/rogervinas/GreetingApplicationTest.kt
@@ -28,7 +28,7 @@ class GreetingApplicationTest {
       ComposeContainer(File("../docker-compose.yaml"))
         .withServices("db", "vault", "vault-cli")
         .withLocalCompose(true)
-        .waitingFor("db", forLogMessage(".*database system is ready to accept connections.*", 1))
+        .waitingFor("db", forLogMessage(".*listening on IPv4 address \"0.0.0.0\", port 5432.*", 1))
         .waitingFor("vault", forLogMessage(".*Development mode.*", 1))
         .waitingFor("vault-cli", forLogMessage(".*created_time.*", 1))
   }

--- a/ktor-app/README.md
+++ b/ktor-app/README.md
@@ -264,7 +264,7 @@ class GreetingApplicationTest {
     private val container = ComposeContainer(File("../docker-compose.yaml"))
       .withServices("db", "vault", "vault-cli")
       .withLocalCompose(true)
-      .waitingFor("db", forLogMessage(".*database system is ready to accept connections.*", 1))
+      .waitingFor("db", forLogMessage(".*listening on IPv4 address \"0.0.0.0\", port 5432.*", 1))
       .waitingFor("vault", forLogMessage(".*Development mode.*", 1))
       .waitingFor("vault-cli", forLogMessage(".*created_time.*", 1))
   }

--- a/ktor-app/src/test/kotlin/org/rogervinas/GreetingApplicationTest.kt
+++ b/ktor-app/src/test/kotlin/org/rogervinas/GreetingApplicationTest.kt
@@ -20,7 +20,7 @@ class GreetingApplicationTest {
       ComposeContainer(File("../docker-compose.yaml"))
         .withServices("db", "vault", "vault-cli")
         .withLocalCompose(true)
-        .waitingFor("db", forLogMessage(".*database system is ready to accept connections.*", 1))
+        .waitingFor("db", forLogMessage(".*listening on IPv4 address \"0.0.0.0\", port 5432.*", 1))
         .waitingFor("vault", forLogMessage(".*Development mode.*", 1))
         .waitingFor("vault-cli", forLogMessage(".*created_time.*", 1))
   }

--- a/springboot-app/README.md
+++ b/springboot-app/README.md
@@ -162,8 +162,9 @@ class GreetingApplicationTest {
     @Container
 	private val container = DockerComposeContainer(File("../docker-compose.yaml"))
 	  .withServices("db", "vault", "vault-cli")
-	  .waitingFor("db", forLogMessage(".*database system is ready to accept connections.*", 1))
+	  .waitingFor("db", forLogMessage(".*listening on IPv4 address \"0.0.0.0\", port 5432.*", 1))
 	  .waitingFor("vault", forLogMessage(".*Development mode.*", 1))
+	  .waitingFor("vault-cli", forLogMessage(".*created_time.*", 1))
   }
 
   @Autowired

--- a/springboot-app/src/test/kotlin/org/rogervinas/GreetingApplicationTest.kt
+++ b/springboot-app/src/test/kotlin/org/rogervinas/GreetingApplicationTest.kt
@@ -23,7 +23,7 @@ class GreetingApplicationTest {
     private val container =
       ComposeContainer(File("../docker-compose.yaml"))
         .withServices("db", "vault", "vault-cli")
-        .waitingFor("db", forLogMessage(".*database system is ready to accept connections.*", 1))
+        .waitingFor("db", forLogMessage(".*listening on IPv4 address \"0.0.0.0\", port 5432.*", 1))
         .waitingFor("vault", forLogMessage(".*Development mode.*", 1))
         .waitingFor("vault-cli", forLogMessage(".*created_time.*", 1))
   }


### PR DESCRIPTION
## Summary
- Wait for `listening on IPv4 address "0.0.0.0", port 5432` instead of `database system is ready to accept connections` (which appears before TCP is ready, causing flaky test failures)
- Fixed in http4k-app, ktor-app, and springboot-app (test code + READMEs)
- Added missing vault-cli wait to springboot README

## Checklist
- Verify integration tests pass reliably on CI for all 3 apps