### PR TITLE
Upgrade Quarkus from 2.15.3 to 3.35.2

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: gradle
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 ![SpringBoot](https://img.shields.io/badge/SpringBoot-4.0.6-blue?labelColor=black)
 
 [![Quarkus](https://github.com/rogervinas/top-5-server-side-kotlin-frameworks-2022/actions/workflows/quarkus.yml/badge.svg)](https://github.com/rogervinas/top-5-server-side-kotlin-frameworks-2022/actions/workflows/quarkus.yml)
-![Java](https://img.shields.io/badge/Java-17-blue?labelColor=black)
+![Java](https://img.shields.io/badge/Java-21-blue?labelColor=black)
 ![Kotlin](https://img.shields.io/badge/Kotlin-2.x-blue?labelColor=black)
-![Quarkus](https://img.shields.io/badge/Quarkus-2.15.3.Final-blue?labelColor=black)
+![Quarkus](https://img.shields.io/badge/Quarkus-3.35.2-blue?labelColor=black)
 
 [![Micronaut](https://github.com/rogervinas/top-5-server-side-kotlin-frameworks-2022/actions/workflows/micronaut.yml/badge.svg)](https://github.com/rogervinas/top-5-server-side-kotlin-frameworks-2022/actions/workflows/micronaut.yml)
 ![Java](https://img.shields.io/badge/Java-17-blue?labelColor=black)

--- a/quarkus-app/README.md
+++ b/quarkus-app/README.md
@@ -7,7 +7,7 @@ You can also check [Creating your first application](https://quarkus.io/guides/g
 To create a simple application with a reactive REST endpoint:
 ```shell
 sdk install quarkus
-quarkus create app org.rogervinas:quarkus-app --gradle-kotlin-dsl --java=17 --kotlin --extension='kotlin,resteasy-reactive-jackson'
+quarkus create app org.rogervinas:quarkus-app --gradle-kotlin-dsl --java=21 --kotlin
 ```
 
 A **Gradle** project will be created with the following:
@@ -24,7 +24,7 @@ quarkus dev
 And make a request to the endpoint:
 ```shell
 curl http://localhost:8080/hello
-Hello from RESTEasy Reactive
+Hello from Quarkus REST
 ```
 
 We can remove the `src/main/resources/META-INF` directory containing some HTML files that we will not need.
@@ -293,13 +293,9 @@ docker compose down
 
 Following [Build a Native Executable](https://quarkus.io/guides/building-native-image):
 ```shell
-# Install GraalVM via sdkman
-sdk install java 22.3.r19-grl
-sdk default java 22.3.r19-grl
-export GRAALVM_HOME=$JAVA_HOME
-
-# Install the native-image
-gu install native-image
+# Install GraalVM for JDK 21 via sdkman
+sdk install java 21-graalce
+sdk use java 21-graalce
 
 # Build native executable
 quarkus build --native

--- a/quarkus-app/README.md
+++ b/quarkus-app/README.md
@@ -27,8 +27,6 @@ curl http://localhost:8080/hello
 Hello from Quarkus REST
 ```
 
-We can remove the `src/main/resources/META-INF` directory containing some HTML files that we will not need.
-
 ## Implementation
 
 ### YAML configuration
@@ -62,30 +60,36 @@ interface GreetingRepository {
 }
 
 @ApplicationScoped
-class GreetingJdbcRepository(private val client: PgPool): GreetingRepository {
-  override fun getGreeting(): String = client
-    .query("SELECT greeting FROM greetings ORDER BY random() LIMIT 1")
-    .executeAndAwait()
-    .map { r -> r.get(String::class.java, "greeting") }
-    .first()
+class GreetingJdbcRepository(
+  private val dataSource: DataSource,
+) : GreetingRepository {
+  override fun getGreeting(): String =
+    dataSource.connection.use { connection ->
+      connection.prepareStatement("SELECT greeting FROM greetings ORDER BY random() LIMIT 1").use { statement ->
+        statement.executeQuery().use { resultSet ->
+          resultSet.next()
+          resultSet.getString("greeting")
+        }
+      }
+    }
 }
 ```
 
-* The `@ApplicationScoped` annotation will make **Quarkus** to create an instance at startup.
-* We inject the [Reactive SQL Client](https://quarkus.io/guides/reactive-sql-clients).
-* We use `query` and that SQL to retrieve one random `greeting` from the `greetings` table.
+* The `@ApplicationScoped` annotation will make **Quarkus** create an instance at startup.
+* We inject a `DataSource` and use plain JDBC to retrieve one random `greeting` from the `greetings` table.
 
 For this to work, we need some extra steps ...
 
-Add the [Reactive SQL Client](https://quarkus.io/guides/reactive-sql-clients) extension:
+Add the JDBC PostgreSQL extension:
 ```shell
-quarkus extension add quarkus-reactive-pg-client
+quarkus extension add quarkus-jdbc-postgresql
 ```
 
-Configure it for `dev` and `test` profiles in `application.yaml`:
+Configure the datasource for `dev` and `test` profiles in `application.yaml`:
 ```yaml
 quarkus:
   datasource:
+    db-kind: "postgresql"
     devservices:
       image-name: "postgres:14.5"
 ```
@@ -97,36 +101,24 @@ quarkus:
     db-kind: "postgresql"
     username: "myuser"
     password: "mypassword"
-    reactive:
-      url: "postgresql://${DB_HOST:localhost}:5432/mydb"
-      max-size: 20
-```
-
-Note that for `dev` and `test` profiles we just use something called "Dev Services", meaning it will automatically start containers and configure the application to use them. You can check the [Dev Services Overview](https://quarkus.io/guides/dev-services) and [Dev Services for Databases](https://quarkus.io/guides/databases-dev-services) documentation. 
-
-To enable [Flyway](https://quarkus.io/guides/flyway) we need to add these dependencies manually (apparently there is no extension):
-```kotlin
-implementation("io.quarkus:quarkus-flyway")
-implementation("io.quarkus:quarkus-jdbc-postgresql")
-```
-
-And, as it seems that we cannot use the same reactive datasource, we will have to configure the standard one:
-* `application.yaml`
-```yaml
-quarkus:
-  flyway:
-    migrate-at-start: true
-```
-* `application-prod.yaml`
-```yaml
-quarkus:
-  datasource:
     jdbc:
       url: "jdbc:postgresql://${DB_HOST:localhost}:5432/mydb"
       max-size: 20
 ```
 
-So `quarkus.datasource.jdbc` will be used by **Flyway** and `quarkus.datasource.reactive` by the application.
+Note that for `dev` and `test` profiles we use "Dev Services", meaning it will automatically start containers and configure the application to use them. You can check the [Dev Services Overview](https://quarkus.io/guides/dev-services) and [Dev Services for Databases](https://quarkus.io/guides/databases-dev-services) documentation.
+
+To enable [Flyway](https://quarkus.io/guides/flyway) we add the extension:
+```shell
+quarkus extension add quarkus-flyway
+```
+
+And configure it in `application.yaml`:
+```yaml
+quarkus:
+  flyway:
+    migrate-at-start: true
+```
 
 Finally, [Flyway](https://flywaydb.org/) migrations under [src/main/resources/db/migration](src/main/resources/db/migration) to create and populate `greetings` table.
 
@@ -137,8 +129,8 @@ We will rename the generated `GreetingResource` class to `GreetingController`, s
 @Path("/hello")
 class GreetingController(
   private val repository: GreetingRepository,
-  @ConfigProperty(name = "greeting.name") private val name: String,
-  @ConfigProperty(name = "greeting.secret", defaultValue = "unknown") private val secret: String
+  @param:ConfigProperty(name = "greeting.name") private val name: String,
+  @param:ConfigProperty(name = "greeting.secret", defaultValue = "unknown") private val secret: String,
 ) {
   @GET
   @Produces(MediaType.TEXT_PLAIN)
@@ -148,11 +140,11 @@ class GreetingController(
 
 * We can inject dependencies via constructor and configuration properties using `@ConfigProperty` annotation.
 * We expect to get `greeting.secret` from **Vault**, that is why we configure `unknown` as its default value, so it does not fail until we configure **Vault** properly.
-* Everything is pretty similar to **Spring Boot**. Note that it uses standard JAX-RS annotations which is also possible in **Spring Boot** (but not by default).
+* Everything is pretty similar to **Spring Boot**. Note that it uses standard Jakarta REST annotations which is also possible in **Spring Boot** (but not by default).
 
 ### Vault configuration
 
-Following the [Using HashiCorp Vault](https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/index.html) guide we add the extension:
+Following the [Using HashiCorp Vault](https://docs.quarkiverse.io/quarkus-vault/dev/index.html) guide we add the extension:
 ```shell
 quarkus extension add vault
 ```

--- a/quarkus-app/build.gradle.kts
+++ b/quarkus-app/build.gradle.kts
@@ -4,8 +4,8 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED
 import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
 
 plugins {
-  kotlin("jvm") version "2.3.10"
-  kotlin("plugin.allopen") version "2.3.10"
+  kotlin("jvm") version "2.3.21"
+  kotlin("plugin.allopen") version "2.3.21"
   id("io.quarkus")
   id("org.jlleitschuh.gradle.ktlint") version "14.0.1"
 }
@@ -23,18 +23,13 @@ val quarkusPlatformArtifactId: String by project
 val quarkusPlatformVersion: String by project
 
 dependencies {
-  implementation("io.quarkiverse.vault:quarkus-vault")
-  implementation("io.quarkus:quarkus-reactive-pg-client")
-  implementation("io.quarkus:quarkus-agroal")
   implementation(enforcedPlatform("$quarkusPlatformGroupId:$quarkusPlatformArtifactId:$quarkusPlatformVersion"))
   implementation("io.quarkus:quarkus-kotlin")
-  implementation("io.quarkus:quarkus-resteasy-reactive-jackson")
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
   implementation("io.quarkus:quarkus-arc")
-  implementation("io.quarkus:quarkus-resteasy-reactive")
-
+  implementation("io.quarkus:quarkus-rest")
   implementation("io.quarkus:quarkus-config-yaml")
-
+  implementation("io.quarkiverse.vault:quarkus-vault")
   implementation("io.quarkus:quarkus-flyway")
   implementation("io.quarkus:quarkus-jdbc-postgresql")
 
@@ -44,14 +39,14 @@ dependencies {
 }
 
 java {
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
-  }
+  sourceCompatibility = JavaVersion.VERSION_21
+  targetCompatibility = JavaVersion.VERSION_21
 }
 
 kotlin {
   compilerOptions {
-    freeCompilerArgs.addAll("-Xjsr305=strict")
+    jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+    javaParameters = true
   }
 }
 
@@ -67,7 +62,8 @@ tasks.withType<Test> {
 }
 
 allOpen {
-  annotation("javax.ws.rs.Path")
-  annotation("javax.enterprise.context.ApplicationScoped")
+  annotation("jakarta.ws.rs.Path")
+  annotation("jakarta.enterprise.context.ApplicationScoped")
+  annotation("jakarta.persistence.Entity")
   annotation("io.quarkus.test.junit.QuarkusTest")
 }

--- a/quarkus-app/gradle.properties
+++ b/quarkus-app/gradle.properties
@@ -1,6 +1,7 @@
-#Gradle properties
+# Gradle properties
+
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=2.15.3.Final
+quarkusPluginVersion=3.35.2
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=2.15.3.Final
+quarkusPlatformVersion=3.35.2

--- a/quarkus-app/gradle/wrapper/gradle-wrapper.properties
+++ b/quarkus-app/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionSha256Sum=17f277867f6914d61b1aa02efab1ba7bb439ad652ca485cd8ca6842fccec6e43
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/quarkus-app/src/main/docker/Dockerfile.jvm
+++ b/quarkus-app/src/main/docker/Dockerfile.jvm
@@ -14,7 +14,9 @@
 # docker run -i --rm -p 8080:8080 quarkus/quarkus-app-jvm
 #
 # If you want to include the debug port into your docker image
-# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
+# you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
+# Additionally you will have to set -e JAVA_DEBUG=true and -e JAVA_DEBUG_PORT=*:5005
+# when running the container
 #
 # Then run the container using :
 #
@@ -24,7 +26,8 @@
 # This scripts computes the command line to execute your Java application, and
 # includes memory/GC tuning.
 # You can configure the behavior using the following environment properties:
-# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class") - Be aware that this will override
+# the default JVM options, use `JAVA_OPTS_APPEND` to append options
 # - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
 #   in JAVA_OPTS (example: "-Dsome.property=foo")
 # - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
@@ -74,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.14
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 
@@ -88,6 +93,8 @@ COPY --chown=185 build/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]
 

--- a/quarkus-app/src/main/docker/Dockerfile.legacy-jar
+++ b/quarkus-app/src/main/docker/Dockerfile.legacy-jar
@@ -3,7 +3,7 @@
 #
 # Before building the container image run:
 #
-# ./gradlew build -Dquarkus.package.type=legacy-jar
+# ./gradlew build -Dquarkus.package.jar.type=legacy-jar
 #
 # Then, build the image with:
 #
@@ -14,7 +14,9 @@
 # docker run -i --rm -p 8080:8080 quarkus/quarkus-app-legacy-jar
 #
 # If you want to include the debug port into your docker image
-# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
+# you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
+# Additionally you will have to set -e JAVA_DEBUG=true and -e JAVA_DEBUG_PORT=*:5005
+# when running the container
 #
 # Then run the container using :
 #
@@ -24,7 +26,8 @@
 # This scripts computes the command line to execute your Java application, and
 # includes memory/GC tuning.
 # You can configure the behavior using the following environment properties:
-# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class") - Be aware that this will override
+# the default JVM options, use `JAVA_OPTS_APPEND` to append options
 # - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
 #   in JAVA_OPTS (example: "-Dsome.property=foo")
 # - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
@@ -74,8 +77,10 @@
 # - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
+# You can find more information about the UBI base runtime images and their configuration here:
+# https://rh-openjdk.github.io/redhat-openjdk-containers/
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.14
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
 
 ENV LANGUAGE='en_US:en'
 
@@ -85,5 +90,7 @@ COPY build/*-runner.jar /deployments/quarkus-run.jar
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]

--- a/quarkus-app/src/main/docker/Dockerfile.native
+++ b/quarkus-app/src/main/docker/Dockerfile.native
@@ -3,7 +3,7 @@
 #
 # Before building the container image run:
 #
-# ./gradlew build -Dquarkus.package.type=native
+# ./gradlew build -Dquarkus.native.enabled=true
 #
 # Then, build the image with:
 #
@@ -13,15 +13,17 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/quarkus-app
 #
+# The ` registry.access.redhat.com/ubi9/ubi-minimal:9.7` base image is based on UBI 9.
+# To use UBI 8, switch to `quay.io/ubi8/ubi-minimal:8.10`.
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
-COPY --chown=1001:root build/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 build/*-runner /work/application
 
 EXPOSE 8080
 USER 1001
 
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/quarkus-app/src/main/docker/Dockerfile.native-micro
+++ b/quarkus-app/src/main/docker/Dockerfile.native-micro
@@ -6,7 +6,7 @@
 #
 # Before building the container image run:
 #
-# ./gradlew build -Dquarkus.package.type=native
+# ./gradlew build -Dquarkus.native.enabled=true
 #
 # Then, build the image with:
 #
@@ -16,15 +16,17 @@
 #
 # docker run -i --rm -p 8080:8080 quarkus/quarkus-app
 #
+# The `quay.io/quarkus/ubi9-quarkus-micro-image:2.0` base image is based on UBI 9.
+# To use UBI 8, switch to `quay.io/quarkus/quarkus-micro-image:2.0`.
 ###
-FROM quay.io/quarkus/quarkus-micro-image:1.0
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
-COPY --chown=1001:root build/*-runner /work/application
+COPY --chown=1001:root --chmod=0755 build/*-runner /work/application
 
 EXPOSE 8080
 USER 1001
 
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/quarkus-app/src/main/kotlin/org/rogervinas/GreetingController.kt
+++ b/quarkus-app/src/main/kotlin/org/rogervinas/GreetingController.kt
@@ -1,16 +1,16 @@
 package org.rogervinas
 
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
 import org.eclipse.microprofile.config.inject.ConfigProperty
-import javax.ws.rs.GET
-import javax.ws.rs.Path
-import javax.ws.rs.Produces
-import javax.ws.rs.core.MediaType
 
 @Path("/hello")
 class GreetingController(
   private val repository: GreetingRepository,
-  @ConfigProperty(name = "greeting.name") private val name: String,
-  @ConfigProperty(name = "greeting.secret", defaultValue = "unknown") private val secret: String,
+  @param:ConfigProperty(name = "greeting.name") private val name: String,
+  @param:ConfigProperty(name = "greeting.secret", defaultValue = "unknown") private val secret: String,
 ) {
   @GET
   @Produces(MediaType.TEXT_PLAIN)

--- a/quarkus-app/src/main/kotlin/org/rogervinas/GreetingRepository.kt
+++ b/quarkus-app/src/main/kotlin/org/rogervinas/GreetingRepository.kt
@@ -1,7 +1,7 @@
 package org.rogervinas
 
-import io.vertx.mutiny.pgclient.PgPool
-import javax.enterprise.context.ApplicationScoped
+import jakarta.enterprise.context.ApplicationScoped
+import javax.sql.DataSource
 
 interface GreetingRepository {
   fun getGreeting(): String
@@ -9,12 +9,15 @@ interface GreetingRepository {
 
 @ApplicationScoped
 class GreetingJdbcRepository(
-  private val client: PgPool,
+  private val dataSource: DataSource,
 ) : GreetingRepository {
   override fun getGreeting(): String =
-    client
-      .query("SELECT greeting FROM greetings ORDER BY random() LIMIT 1")
-      .executeAndAwait()
-      .map { r -> r.get(String::class.java, "greeting") }
-      .first()
+    dataSource.connection.use { connection ->
+      connection.prepareStatement("SELECT greeting FROM greetings ORDER BY random() LIMIT 1").use { statement ->
+        statement.executeQuery().use { resultSet ->
+          resultSet.next()
+          resultSet.getString("greeting")
+        }
+      }
+    }
 }

--- a/quarkus-app/src/main/resources/application-prod.yaml
+++ b/quarkus-app/src/main/resources/application-prod.yaml
@@ -6,9 +6,6 @@ quarkus:
     jdbc:
       url: "jdbc:postgresql://${DB_HOST:localhost}:5432/mydb"
       max-size: 20
-    reactive:
-      url: "postgresql://${DB_HOST:localhost}:5432/mydb"
-      max-size: 20
   vault:
     url: "http://${VAULT_HOST:localhost}:8200"
     authentication:

--- a/quarkus-app/src/main/resources/application.yaml
+++ b/quarkus-app/src/main/resources/application.yaml
@@ -3,6 +3,7 @@ greeting:
 
 quarkus:
   datasource:
+    db-kind: "postgresql"
     devservices:
       image-name: "postgres:14.5"
   flyway:

--- a/quarkus-app/src/test/kotlin/org/rogervinas/GreetingControllerTest.kt
+++ b/quarkus-app/src/test/kotlin/org/rogervinas/GreetingControllerTest.kt
@@ -1,8 +1,8 @@
 package org.rogervinas
 
+import io.quarkus.test.InjectMock
 import io.quarkus.test.common.http.TestHTTPEndpoint
 import io.quarkus.test.junit.QuarkusTest
-import io.quarkus.test.junit.mockito.InjectMock
 import io.restassured.RestAssured.`when`
 import org.hamcrest.CoreMatchers.`is`
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
## Summary
- Upgrade Quarkus from 2.15.3.Final to 3.35.2
- Upgrade Kotlin 2.3.10 → 2.3.21, Gradle 8.12 → 9.3.1, Java 17 → 21
- Migrate javax.* → jakarta.* namespace
- Replace resteasy-reactive with quarkus-rest
- Simplify GreetingRepository from reactive PgPool to plain JDBC DataSource
- Update Dockerfiles to UBI 9 / OpenJDK 21
- Update GraalVM native build instructions in README

## Checklist
- Verify quarkus dev starts and /hello endpoint works
- Confirm Flyway migrations run at startup
- Confirm tests pass in CI