### PR TITLE
Add JDBI ConfigCaches to GraalVM native reflection config

### DIFF
--- a/micronaut-app/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/micronaut-app/src/main/resources/META-INF/native-image/reflect-config.json
@@ -5848,14 +5848,7 @@
   },
   {
     "name": "org.jdbi.v3.core.config.internal.ConfigCaches",
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": [
-          "org.jdbi.v3.core.config.ConfigRegistry"
-        ]
-      }
-    ]
+    "allDeclaredConstructors": true
   },
   {
     "name": "org.jdbi.v3.core.mapper.ColumnMappers",

--- a/micronaut-app/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/micronaut-app/src/main/resources/META-INF/native-image/reflect-config.json
@@ -5847,6 +5847,17 @@
     ]
   },
   {
+    "name": "org.jdbi.v3.core.config.internal.ConfigCaches",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jdbi.v3.core.config.ConfigRegistry"
+        ]
+      }
+    ]
+  },
+  {
     "name": "org.jdbi.v3.core.mapper.ColumnMappers",
     "methods": [
       {


### PR DESCRIPTION
## Summary
- Add `org.jdbi.v3.core.config.internal.ConfigCaches` constructor to native-image reflect-config.json
- Fixes native executable failing on first request with `NoSuchMethodException`

## Checklist
- Build native image and verify `/hello` endpoint works